### PR TITLE
bug: try to fix `MemWriteOnExecutablePage` error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "131bddab59a64213cc1e9f0c5be010d7eb485951358ab7e52017888dec482028"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,6 +144,12 @@ checksum = "d4fd9767ab5e5f2ea40f71ff4c8bdb633c50509052e093c2fdd0e390a749dfa3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spore"
@@ -178,6 +193,7 @@ version = "0.1.0"
 dependencies = [
  "ckb-hash",
  "ckb-std",
+ "lazy_static",
  "spore-errors",
  "spore-utils",
 ]

--- a/contracts/spore_extension_lua/Cargo.toml
+++ b/contracts/spore_extension_lua/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 ckb-std = "0.14.3"
 spore-utils = { path = "../../lib/utils" }
 spore-errors = { path = "../../lib/errors" }
+lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 
 [build-dependencies]
 ckb-hash = "0.112.1"

--- a/contracts/spore_extension_lua/src/entry.rs
+++ b/contracts/spore_extension_lua/src/entry.rs
@@ -4,6 +4,7 @@ use core::result::Result;
 use alloc::borrow::ToOwned;
 // Import heap related library from `alloc`
 // https://doc.rust-lang.org/alloc/index.html
+use alloc::boxed::Box;
 use alloc::ffi::CString;
 use alloc::string::String;
 use alloc::{format, vec, vec::Vec};
@@ -40,7 +41,7 @@ struct CKBLuaLib {
 
 impl CKBLuaLib {
     pub fn new() -> Result<Self, Error> {
-        let mut context = unsafe { CKBDLContext::<[u8; 270 * 1024]>::new() };
+        let mut context = Box::new(unsafe { CKBDLContext::<[u8; 384 * 1024]>::new() });
         #[allow(deprecated)]
         let lib = context
             .load(&CKB_LUA_LIB_CODE_HASH)

--- a/contracts/spore_extension_lua/src/main.rs
+++ b/contracts/spore_extension_lua/src/main.rs
@@ -20,7 +20,7 @@ use ckb_std::default_alloc;
 #[cfg(not(test))]
 ckb_std::entry!(program_entry);
 #[cfg(not(test))]
-default_alloc!(6 * 1024, 800 * 1024, 64);
+default_alloc!(4 * 1024, 1024 * 1024, 64);
 
 /// program entry
 pub fn program_entry() -> i8 {


### PR DESCRIPTION
# Description
We meet error `MemWriteOnExecutablePage` while using Mutant Cell to create Spore Cell, after discussing with `by`, I think  the solution is to move the dynamic load of `libckblua.so` from stack to heap, this can save stack memory