### PR TITLE
bug: fix payment check conflict and flag impact for type hash

### DIFF
--- a/.github/workflows/devnet.yaml
+++ b/.github/workflows/devnet.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Prepare spore-devenv (contracts and stuff)
         working-directory: spore-devenv
-        run: sh prepare.sh
+        run: bash prepare.sh -b $GITHUB_HEAD_REF
 
       - name: Start devenv services
         working-directory: spore-devenv

--- a/.github/workflows/devnet.yaml
+++ b/.github/workflows/devnet.yaml
@@ -1,0 +1,85 @@
+# Test the functionality of the spore-sdk packages.
+
+name: Devnet Test
+
+on:
+  pull_request:
+    paths:
+      - contracts/**
+      - lib/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  devnet:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout spore-devenv
+        uses: actions/checkout@v4
+        with:
+          repository: Dawn-githup/spore_devenv
+          path: spore-devenv
+
+      - name: Checkout spore-sdk
+        uses: actions/checkout@v4
+        with:
+          repository: sporeprotocol/spore-sdk
+          path: spore-sdk
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20.x
+
+      - uses: pnpm/action-setup@v2
+        name: Install -g pnpm
+        with:
+          version: 8
+          run_install: false
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Prepare spore-devenv (contracts and stuff)
+        working-directory: spore-devenv
+        run: sh prepare.sh
+
+      - name: Start devenv services
+        working-directory: spore-devenv
+        run: npm run test:start
+
+      - name: Move generated config file to spore-sdk
+        working-directory: spore-devenv
+        run: |
+          mkdir -p ../spore-sdk/packages/core/src/__tests__/tmp
+          cp config.json ../spore-sdk/packages/core/src/__tests__/tmp
+
+      - name: Recharge capacity for accounts
+        working-directory: spore-devenv
+        run: npm run test:e2e
+        env:
+          VITE_ACCOUNT_CHARLIE: ${{ secrets.ACCOUNT_CHARLIE }}
+          VITE_ACCOUNT_ALICE: ${{ secrets.ACCOUNT_ALICE }}
+
+      - name: Prepare spore-sdk
+        working-directory: spore-sdk
+        run: pnpm install
+
+      - name: Run tests for @spore-sdk/core
+        working-directory: spore-sdk/packages/core
+        run: pnpm run test
+        env:
+          VITE_ACCOUNT_CHARLIE: ${{ secrets.ACCOUNT_CHARLIE }}
+          VITE_ACCOUNT_ALICE: ${{ secrets.ACCOUNT_ALICE }}
+          VITE_NETWORK: devnet

--- a/.github/workflows/devnet.yaml
+++ b/.github/workflows/devnet.yaml
@@ -3,6 +3,7 @@
 name: Devnet Test
 
 on:
+  push:
   pull_request:
     paths:
       - contracts/**

--- a/.github/workflows/devnet.yaml
+++ b/.github/workflows/devnet.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout spore-devenv
         uses: actions/checkout@v4
         with:
-          repository: Dawn-githup/spore_devenv
+          repository: sporeprotocol/spore-devenv
           path: spore-devenv
 
       - name: Checkout spore-sdk

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,62 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "ahash"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
+dependencies = [
+ "getrandom 0.2.12",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "blake2b-ref"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95916998c798756098a4eb1b3f2cd510659705a9817bf203d61abd30fbec3e7b"
+
+[[package]]
 name = "blake2b-ref"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +81,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f0d2da64a6a895d5a7e0724882825d50f83c13396b1b9f1878e19a024bab395"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,13 +111,266 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "ckb-always-success-script"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b3b72a38c9920a29990df12002c4d069a147c8782f0c211f8a01b2df8f42bfd"
+
+[[package]]
+name = "ckb-chain-spec"
+version = "0.108.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76db6b5000404d17db8b533b073693e02a64989c5d99bea87e51ae51663577b7"
+dependencies = [
+ "ckb-constant",
+ "ckb-crypto",
+ "ckb-dao-utils",
+ "ckb-error",
+ "ckb-hash 0.108.1",
+ "ckb-jsonrpc-types",
+ "ckb-pow",
+ "ckb-rational",
+ "ckb-resource",
+ "ckb-traits",
+ "ckb-types",
+ "ckb-util",
+ "serde",
+ "toml 0.5.11",
+]
+
+[[package]]
+name = "ckb-channel"
+version = "0.108.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52664e02e09542635e1f1c831106ffd8ff4b45f779084b2b0eba1776bbe7cefa"
+dependencies = [
+ "crossbeam-channel",
+]
+
+[[package]]
+name = "ckb-constant"
+version = "0.108.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20be5e1878b20d693945c0537fc813970aa61849bf89525c548afa1ad4a3e7d7"
+
+[[package]]
+name = "ckb-crypto"
+version = "0.108.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb6ff995bead74fdba3d6993e8c320493a8a27de9735327be3d2e7275e362b7c"
+dependencies = [
+ "ckb-fixed-hash",
+ "faster-hex 0.6.1",
+ "lazy_static",
+ "rand 0.7.3",
+ "secp256k1",
+ "thiserror",
+]
+
+[[package]]
+name = "ckb-dao"
+version = "0.108.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680671d127c45ec5907bc8a2958e8d6fbbe6d602daff1b477f8bda3e362382eb"
+dependencies = [
+ "byteorder",
+ "ckb-chain-spec",
+ "ckb-dao-utils",
+ "ckb-traits",
+ "ckb-types",
+]
+
+[[package]]
+name = "ckb-dao-utils"
+version = "0.108.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fdca090384bd478ea70034d769896ac5053768d31c914c241077221d7664ec"
+dependencies = [
+ "byteorder",
+ "ckb-error",
+ "ckb-types",
+]
+
+[[package]]
+name = "ckb-error"
+version = "0.108.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32775db75fb537c1674c606d0544a90387b66bf26f124db5733ef6ef925c93cf"
+dependencies = [
+ "anyhow",
+ "ckb-occupied-capacity",
+ "derive_more",
+ "thiserror",
+]
+
+[[package]]
+name = "ckb-fixed-hash"
+version = "0.108.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0571fbe9584fdbabbd884f9d3f911b163f57c7d61d1df0191f945ac03ceca9b6"
+dependencies = [
+ "ckb-fixed-hash-core",
+ "ckb-fixed-hash-macros",
+]
+
+[[package]]
+name = "ckb-fixed-hash-core"
+version = "0.108.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "548c4f95e73c37b542969580c41635b830d9b79f2486d99944b3fd30c6e64b2f"
+dependencies = [
+ "faster-hex 0.6.1",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "ckb-fixed-hash-macros"
+version = "0.108.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602f5d9c05f3462e906faa76639217f0965be5a3607902a222bcd2b060be796e"
+dependencies = [
+ "ckb-fixed-hash-core",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ckb-hash"
+version = "0.108.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28573f714520e678df48ab448964188cca7c6b33a6623f184939e13f5585e488"
+dependencies = [
+ "blake2b-ref 0.2.1",
+ "blake2b-rs",
+]
+
+[[package]]
 name = "ckb-hash"
 version = "0.112.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25af660fc8746f7c756444e6aa47ede9a874206563b6a1ce1b230a5b86519392"
 dependencies = [
- "blake2b-ref",
+ "blake2b-ref 0.3.1",
  "blake2b-rs",
+]
+
+[[package]]
+name = "ckb-jsonrpc-types"
+version = "0.108.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069a36e5b50b1f7d83d77b472ab4dab5e942c0b2ea3f5671a7746a41455643d0"
+dependencies = [
+ "ckb-types",
+ "faster-hex 0.6.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "ckb-logger"
+version = "0.108.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b0557af281ed888f09e2aebb0bcdf0ba3b02052e99ef30ad6a90a6f5c21803"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "ckb-merkle-mountain-range"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ccb671c5921be8a84686e6212ca184cb1d7c51cadcdbfcbd1cc3f042f5dfb8"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "ckb-occupied-capacity"
+version = "0.108.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83b3f7d79fa763cad6d44bc9bbe1a18daf16c9b3d0e87564f9b24eb8c43d8e8f"
+dependencies = [
+ "ckb-occupied-capacity-core",
+ "ckb-occupied-capacity-macros",
+]
+
+[[package]]
+name = "ckb-occupied-capacity-core"
+version = "0.108.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dea39dd079179a501de5c94535797aaa5748a8565fb75bf37afaaae392d4ecf"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "ckb-occupied-capacity-macros"
+version = "0.108.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be56062c13455b3c56d127c70682cf8282a083f858c89fe6b7e8af3f67da038b"
+dependencies = [
+ "ckb-occupied-capacity-core",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ckb-pow"
+version = "0.108.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cf952a3a1cac25e8d8c26d1a578e7256808f83594c7826e71b24b6114ee7ddb"
+dependencies = [
+ "byteorder",
+ "ckb-hash 0.108.1",
+ "ckb-types",
+ "eaglesong",
+ "log",
+ "serde",
+]
+
+[[package]]
+name = "ckb-rational"
+version = "0.108.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cc0a4e5addb15cca41bce2e7b901276002be4fcca27fdeb3165ad7b7c5ebecb"
+dependencies = [
+ "numext-fixed-uint",
+ "serde",
+]
+
+[[package]]
+name = "ckb-resource"
+version = "0.108.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eefc5c051e975acc95dcb74089502b0b23cb59a9b2c38b907a08677d87ec940"
+dependencies = [
+ "ckb-system-scripts",
+ "ckb-types",
+ "includedir",
+ "includedir_codegen",
+ "phf",
+ "serde",
+ "walkdir",
+]
+
+[[package]]
+name = "ckb-script"
+version = "0.108.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e052a3832a90f6b4be8d9545657f0a0eb27391d4654aadcafbd0b3e24834a96d"
+dependencies = [
+ "byteorder",
+ "ckb-chain-spec",
+ "ckb-error",
+ "ckb-hash 0.108.1",
+ "ckb-logger",
+ "ckb-traits",
+ "ckb-types",
+ "ckb-vm",
+ "faster-hex 0.6.1",
+ "serde",
 ]
 
 [[package]]
@@ -55,7 +379,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5c776d70eb4f60a22a3180857646d77b2da8d33c0c4a063ad9f6610fc94609f"
 dependencies = [
- "blake2b-ref",
+ "blake2b-ref 0.3.1",
  "cfg-if",
  "molecule",
 ]
@@ -72,10 +396,147 @@ dependencies = [
 ]
 
 [[package]]
+name = "ckb-system-scripts"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa5c59063142de7a68cfad4449c6b3863563856219a2925dfb8c5f019ec2aa47"
+dependencies = [
+ "blake2b-rs",
+ "faster-hex 0.6.1",
+ "includedir",
+ "includedir_codegen",
+ "phf",
+]
+
+[[package]]
+name = "ckb-systemtime"
+version = "0.108.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34104cf87242b62ce604ab0d9126e057549a4051a5c26985ac0ac04b77054021"
+
+[[package]]
+name = "ckb-testtool"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ed676eb4411676d2e507067a714905fea8842ba2e0c0ac5ede68fe350b5547"
+dependencies = [
+ "ckb-always-success-script",
+ "ckb-chain-spec",
+ "ckb-crypto",
+ "ckb-error",
+ "ckb-hash 0.108.1",
+ "ckb-jsonrpc-types",
+ "ckb-resource",
+ "ckb-script",
+ "ckb-traits",
+ "ckb-types",
+ "ckb-verification",
+ "lazy_static",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "ckb-traits"
+version = "0.108.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c5fa4950994edb7efd35d035afc5f5f4739dd056f9c54ead62991c8f2f4f0fc"
+dependencies = [
+ "ckb-types",
+]
+
+[[package]]
+name = "ckb-types"
+version = "0.108.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db89f3d3c39dd9f4bc8887b9e675df087e888e4db748d8a1e02efbbc0f01e18f"
+dependencies = [
+ "bit-vec",
+ "bytes",
+ "ckb-channel",
+ "ckb-error",
+ "ckb-fixed-hash",
+ "ckb-hash 0.108.1",
+ "ckb-merkle-mountain-range",
+ "ckb-occupied-capacity",
+ "ckb-rational",
+ "derive_more",
+ "merkle-cbt",
+ "molecule",
+ "numext-fixed-uint",
+ "once_cell",
+]
+
+[[package]]
+name = "ckb-util"
+version = "0.108.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050fcae575aa6bdb3d33197992da9ef7c8d7b3d5ad9be9bb702ebf211ed8f3d4"
+dependencies = [
+ "linked-hash-map",
+ "once_cell",
+ "parking_lot",
+ "regex",
+]
+
+[[package]]
+name = "ckb-verification"
+version = "0.108.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ced4c09b7bfb71ab14e883a6c93eaefd14eca743ba9368f142cc14487bb53d"
+dependencies = [
+ "ckb-chain-spec",
+ "ckb-dao",
+ "ckb-dao-utils",
+ "ckb-error",
+ "ckb-pow",
+ "ckb-script",
+ "ckb-systemtime",
+ "ckb-traits",
+ "ckb-types",
+ "ckb-verification-traits",
+ "derive_more",
+ "lru",
+]
+
+[[package]]
+name = "ckb-verification-traits"
+version = "0.108.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb7170a12953742a41b7eb9a7f63c684daedd36e5447d7bfb96fcba40a94cc8"
+dependencies = [
+ "bitflags",
+ "ckb-error",
+]
+
+[[package]]
+name = "ckb-vm"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1223acc8054ce96f91c5d99d4942898d0bdadd618c3b14f1acd3e67212991d8e"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "cc",
+ "ckb-vm-definitions",
+ "derive_more",
+ "goblin 0.2.3",
+ "goblin 0.4.0",
+ "rand 0.7.3",
+ "scroll",
+ "serde",
+]
+
+[[package]]
+name = "ckb-vm-definitions"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4af800ae2b6c54b70efa398dab015a09a52eeac2dd1ac3ad32c9bbe224974225"
+
+[[package]]
 name = "cluster"
 version = "0.1.0"
 dependencies = [
- "ckb-hash",
+ "ckb-hash 0.112.1",
  "ckb-std",
  "spore-build-tools",
  "spore-errors",
@@ -87,7 +548,7 @@ dependencies = [
 name = "cluster_agent"
 version = "0.1.0"
 dependencies = [
- "ckb-hash",
+ "ckb-hash 0.112.1",
  "ckb-std",
  "spore-build-tools",
  "spore-errors",
@@ -98,7 +559,7 @@ dependencies = [
 name = "cluster_proxy"
 version = "0.1.0"
 dependencies = [
- "ckb-hash",
+ "ckb-hash 0.112.1",
  "ckb-std",
  "hex",
  "spore-build-tools",
@@ -107,10 +568,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
 name = "cty"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "eaglesong"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d978bd5d343e8ab9b5c0fc8d93ff9c602fdc96616ffff9c05ac7a155419b824"
 
 [[package]]
 name = "equivalent"
@@ -120,9 +630,78 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "faster-hex"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e2ce894d53b295cf97b05685aa077950ff3e8541af83217fc720a6437169f8"
+
+[[package]]
+name = "faster-hex"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183"
+
+[[package]]
+name = "flate2"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "goblin"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d20fd25aa456527ce4f544271ae4fea65d2eda4a6561ea56f39fb3ee4f7e3884"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
+]
+
+[[package]]
+name = "goblin"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532a09cd3df2c6bbfc795fb0434bff8f22255d1d07328180e918a2e6ce122d4d"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -131,10 +710,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
+name = "heapsize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1679e6ea370dee694f91f1dc469bf94cf8f52051d147aec3e1f9497c6fc22461"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "includedir"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afd126bd778c00c43a9dc76d1609a0894bf4222088088b2217ccc0ce9e816db7"
+dependencies = [
+ "flate2",
+ "phf",
+]
+
+[[package]]
+name = "includedir_codegen"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ac1500c9780957c9808c4ec3b94002f35aab01483833f5a8bce7dfb243e3148"
+dependencies = [
+ "flate2",
+ "phf_codegen",
+ "walkdir",
+]
 
 [[package]]
 name = "indexmap"
@@ -143,8 +752,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.3",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "kmp"
@@ -153,10 +768,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "131bddab59a64213cc1e9f0c5be010d7eb485951358ab7e52017888dec482028"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "lru"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
+dependencies = [
+ "hashbrown 0.12.3",
+]
 
 [[package]]
 name = "memchr"
@@ -165,13 +820,158 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
+name = "merkle-cbt"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171d2f700835121c3b04ccf0880882987a050fd5c7ae88148abf537d33dd3a56"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "molecule"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edc8276c02a006bddad7d1c28c1a88f30421e1b5f0ba0ca96ceb8077c7d20c01"
 dependencies = [
+ "bytes",
  "cfg-if",
+ "faster-hex 0.6.1",
 ]
+
+[[package]]
+name = "numext-constructor"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "621fe0f044729f810c6815cdd77e8f5e0cd803ce4f6a38380ebfc1322af98661"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "numext-fixed-uint"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c68c76f96d589d1009a666c5072f37f3114d682696505f2cf445f27766c7d70"
+dependencies = [
+ "numext-fixed-uint-core",
+ "numext-fixed-uint-hack",
+]
+
+[[package]]
+name = "numext-fixed-uint-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aab1d6457b97b49482f22a92f0f58a2f39bdd7f3b2f977eae67e8bc206aa980"
+dependencies = [
+ "heapsize",
+ "numext-constructor",
+ "rand 0.7.3",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "numext-fixed-uint-hack"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0200f8d55c36ec1b6a8cf810115be85d4814f045e0097dfd50033ba25adb4c9e"
+dependencies = [
+ "numext-fixed-uint-core",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
+name = "phf"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
+dependencies = [
+ "phf_shared",
+ "rand 0.7.3",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
@@ -192,6 +992,199 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+ "rand_pcg",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.12",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scroll"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaaae8f38bb311444cfb7f1979af0bc9240d95795f75f9ceddf6a59b79ceffa0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1629c9c557ef9b293568b338dddfc8208c98a18c59d722a9d53f859d9c9b62"
+dependencies = [
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
+
+[[package]]
 name = "serde"
 version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,7 +1201,18 @@ checksum = "a3385e45322e8f9931410f01b3031ec534c3947d0e94c18049af4d9f9907d4e0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -221,10 +1225,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "smallvec"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+
+[[package]]
 name = "spore"
 version = "0.1.0"
 dependencies = [
- "ckb-hash",
+ "ckb-hash 0.112.1",
  "ckb-std",
  "hex",
  "kmp",
@@ -238,9 +1254,9 @@ dependencies = [
 name = "spore-build-tools"
 version = "0.1.0"
 dependencies = [
- "faster-hex",
+ "faster-hex 0.9.0",
  "serde",
- "toml",
+ "toml 0.8.8",
 ]
 
 [[package]]
@@ -270,10 +1286,21 @@ dependencies = [
 name = "spore_extension_lua"
 version = "0.1.0"
 dependencies = [
- "ckb-hash",
+ "ckb-hash 0.112.1",
  "ckb-std",
  "spore-errors",
  "spore-utils",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -285,6 +1312,45 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tests"
+version = "0.1.0"
+dependencies = [
+ "ckb-testtool",
+ "hex",
+ "spore-types",
+ "spore-utils",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -326,6 +1392,122 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,16 @@ members = [
     "lib/types",
     "lib/utils",
     "lib/errors",
+    "lib/build",
 
     "contracts/spore",
     "contracts/cluster",
     "contracts/cluster_proxy",
     "contracts/cluster_agent",
     "contracts/spore_extension_lua",
+
+    "tests",
 ]
-exclude = ["tests"]
 
 [profile.release]
 overflow-checks = true

--- a/contracts/cluster_agent/src/entry.rs
+++ b/contracts/cluster_agent/src/entry.rs
@@ -70,6 +70,7 @@ fn process_creation(_index: usize) -> Result<(), Error> {
         if proxy_type_args.len() > CLUSTER_PROXY_ID_LEN {
             let minimal_payment_args = proxy_type_args.get(CLUSTER_PROXY_ID_LEN).unwrap_or(&0);
             debug!("Minimal payment is: {}", minimal_payment_args);
+
             let minimal_payment = 10u128.pow(*minimal_payment_args as u32);
             let lock = load_cell_lock_hash(cell_dep_index, CellDep)?;
             let input_capacity = calc_capacity_sum(&lock, Input);

--- a/contracts/cluster_agent/src/entry.rs
+++ b/contracts/cluster_agent/src/entry.rs
@@ -23,7 +23,7 @@ fn is_valid_cluster_proxy_cell(script_hash: &[u8; 32]) -> bool {
 fn has_conflict_agent(source: Source, cell_data: &[u8]) -> bool {
     let script = load_script().unwrap_or_default();
     let self_code_hash = script.code_hash();
-    let same_agents = QueryIter::new(load_cell_type, source)
+    let agents_count = QueryIter::new(load_cell_type, source)
         .enumerate()
         .filter(|(index, type_)| {
             if let Some(type_) = type_ {
@@ -34,8 +34,8 @@ fn has_conflict_agent(source: Source, cell_data: &[u8]) -> bool {
             }
             false
         })
-        .collect::<Vec<_>>();
-    same_agents.len() > 1
+        .count();
+    agents_count > 1
 }
 
 fn process_creation(_index: usize) -> Result<(), Error> {
@@ -77,7 +77,7 @@ fn process_creation(_index: usize) -> Result<(), Error> {
             if input_capacity + minimal_payment < output_capacity {
                 return Err(Error::PaymentNotEnough);
             } else {
-                // Condition 3: Check only one agent in creation
+                // Condition 3: Check no same agent in creation
                 if has_conflict_agent(Source::Output, &proxy_type_hash) {
                     return Err(Error::ConflictAgentCells);
                 }

--- a/contracts/cluster_agent/src/entry.rs
+++ b/contracts/cluster_agent/src/entry.rs
@@ -74,7 +74,7 @@ fn process_creation(_index: usize) -> Result<(), Error> {
             let lock = load_cell_lock_hash(cell_dep_index, CellDep)?;
             let input_capacity = calc_capacity_sum(&lock, Input);
             let output_capacity = calc_capacity_sum(&lock, Output);
-            if input_capacity + minimal_payment < output_capacity {
+            if input_capacity + minimal_payment > output_capacity {
                 return Err(Error::PaymentNotEnough);
             } else {
                 // Condition 3: Check no same agent in creation

--- a/contracts/cluster_proxy/src/entry.rs
+++ b/contracts/cluster_proxy/src/entry.rs
@@ -9,8 +9,6 @@ use spore_utils::{
     find_position_by_lock_hash, find_position_by_type, find_position_by_type_args, verify_type_id,
 };
 
-const CLUSTER_PROXY_ID_LEN: usize = 32;
-
 fn is_valid_cluster_cell(script_hash: &[u8; 32]) -> bool {
     crate::hash::CLUSTER_CODE_HASHES.contains(script_hash)
 }
@@ -46,13 +44,10 @@ fn process_creation(index: usize) -> Result<(), Error> {
 }
 
 fn process_transfer() -> Result<(), Error> {
-    let input_proxy_type = load_cell_type(0, GroupInput)?.unwrap_or_default();
-    let output_proxy_type = load_cell_type(0, GroupOutput)?.unwrap_or_default();
+    let input_data = load_cell_data(0, GroupInput)?;
+    let output_data = load_cell_data(0, GroupOutput)?;
 
-    // NOTE: We allow minimal payment modification during transfer
-    if input_proxy_type.args().raw_data()[..CLUSTER_PROXY_ID_LEN]
-        != output_proxy_type.args().raw_data()[..CLUSTER_PROXY_ID_LEN]
-    {
+    if input_data != output_data {
         return Err(Error::ImmutableProxyFieldModification);
     }
 

--- a/contracts/spore/build.rs
+++ b/contracts/spore/build.rs
@@ -17,6 +17,7 @@ pub fn main() {
     let compile_mode = env::var("PROFILE").unwrap();
     let cluster_code_hash = load_code_hash("cluster", &compile_mode);
     let cluster_agent_code_hash = load_code_hash("cluster_agent", &compile_mode);
+    let mutant_code_hash = load_code_hash("spore_extension_lua", &compile_mode);
 
     let frozen = load_frozen_toml();
     let cluster_code_hashes = [frozen.cluster_code_hashes(), vec![cluster_code_hash]].concat();
@@ -25,8 +26,10 @@ pub fn main() {
         vec![cluster_agent_code_hash],
     ]
     .concat();
+    let mutant_code_hashes = [frozen.mutant_code_hashes(), vec![mutant_code_hash]].concat();
 
     let mut content = concat_code_hashes("CLUSTER_CODE_HASHES", &cluster_code_hashes);
     content += concat_code_hashes("CLUSTER_AGENT_CODE_HASHES", &cluster_agent_code_hashes).as_str();
+    content += concat_code_hashes("MUTANT_CODE_HASHES", &mutant_code_hashes).as_str();
     fs::write("./src/hash.rs", content).unwrap();
 }

--- a/contracts/spore/src/entry.rs
+++ b/contracts/spore/src/entry.rs
@@ -253,7 +253,7 @@ fn check_payment(ext_pos: usize) -> Result<(), Error> {
         let payment_power = ext_args.get(32).cloned().unwrap_or(0);
         let minimal_payment = 10u128.pow(payment_power as u32);
 
-        if input_capacity + minimal_payment < output_capacity {
+        if input_capacity + minimal_payment > output_capacity {
             return Err(Error::ExtensionPaymentNotEnough);
         }
     }

--- a/contracts/spore/src/entry.rs
+++ b/contracts/spore/src/entry.rs
@@ -52,8 +52,15 @@ fn process_creation(index: usize) -> Result<(), Error> {
     let content_type = raw_content_type.unpack();
 
     let mime = MIME::parse(content_type)?; // content_type validation
+    // Spore supports [MIME-multipart](https://datatracker.ietf.org/doc/html/rfc1521#section-7.2).
+    //
+    // The Multipart Content-Type is used to represent a document that is comprised of multiple
+    // parts, each of which may have its own individual MIME type
     if content_type[mime.main_type.clone()] == "multipart".as_bytes()[..] {
         // Check if boundary param exists
+        // The Content-Type field for multipart entities requires one parameter, "boundary", which
+        // is used to specify the encapsulation boundary. See Appendix C of rfc1521 for a complex
+        // multipart example.
         let boundary_range = mime
             .get_param(content_type, "boundary")?
             .ok_or(Error::InvalidContentType)?;

--- a/contracts/spore/src/entry.rs
+++ b/contracts/spore/src/entry.rs
@@ -250,7 +250,9 @@ fn check_payment(ext_pos: usize) -> Result<(), Error> {
 
         let input_capacity = calc_capacity_sum(&self_lock_hash, Input);
         let output_capacity = calc_capacity_sum(&mutant_lock_hash, Output);
-        let minimal_payment = 10u128.pow(ext_args.get(32).cloned().unwrap_or(0) as u32);
+        let payment_power = ext_args.get(32).cloned().unwrap_or(0);
+        let minimal_payment = 10u128.pow(payment_power as u32);
+
         if input_capacity + minimal_payment < output_capacity {
             return Err(Error::ExtensionPaymentNotEnough);
         }

--- a/contracts/spore_extension_lua/src/entry.rs
+++ b/contracts/spore_extension_lua/src/entry.rs
@@ -139,14 +139,11 @@ fn process_creation(index: usize) -> Result<(), WrappedError> {
 fn process_transfer() -> Result<(), WrappedError> {
     let input_data = load_cell_data(0, GroupInput)?;
     let output_data = load_cell_data(0, GroupOutput)?;
-    if input_data.len() != output_data.len()
-        && input_data
-            .iter()
-            .zip(output_data.iter())
-            .all(|(i, o)| i == o)
-    {
+
+    if input_data != output_data {
         return Err(Error::ModifyExtensionPermanentField.into());
     }
+
     Ok(())
 }
 

--- a/lib/build/src/lib.rs
+++ b/lib/build/src/lib.rs
@@ -17,6 +17,7 @@ pub struct PublishedCodeHash {
 }
 
 fn hex_to_byte32(hex: &str) -> [u8; 32] {
+    assert!(hex.len() == 64, "only accept [u8; 32] as hex string");
     let mut byte32 = [0u8; 32];
     hex_decode(hex.as_bytes(), &mut byte32).expect("hex to byte32");
     byte32

--- a/lib/errors/src/error.rs
+++ b/lib/errors/src/error.rs
@@ -38,6 +38,7 @@ pub enum Error {
     PaymentNotEnough,
     PaymentMethodNotSupport,
     RefCellNotClusterProxy,
+    ConflictAgentCells,
 
     // cluster errors
     InvalidClusterOperation = 50,

--- a/lib/errors/src/error.rs
+++ b/lib/errors/src/error.rs
@@ -70,6 +70,8 @@ pub enum Error {
     InvalidParams,
     InvalidParamValue,
     MutantIDNotValid,
+    DuplicateMutantId,
+    ContentOutOfRange,
 
     Unknown,
 }

--- a/lib/utils/src/lib.rs
+++ b/lib/utils/src/lib.rs
@@ -2,7 +2,6 @@
 
 extern crate alloc;
 
-use alloc::vec::Vec;
 use ckb_std::ckb_constants::Source;
 use ckb_std::ckb_types::packed::Script;
 use ckb_std::ckb_types::prelude::*;
@@ -10,7 +9,7 @@ use ckb_std::ckb_types::util::hash::Blake2bBuilder;
 use ckb_std::debug;
 use ckb_std::high_level::{
     load_cell, load_cell_data, load_cell_lock_hash, load_cell_type, load_cell_type_hash,
-    load_input, load_script, QueryIter,
+    load_input, QueryIter,
 };
 
 pub use mime::MIME;
@@ -126,18 +125,4 @@ pub fn calc_capacity_sum(lock_hash: &[u8; 32], source: Source) -> u128 {
         .filter(|cell| cell.lock().calc_script_hash().raw_data().as_ref() == lock_hash)
         .map(|cell| cell.capacity().unpack() as u128)
         .sum()
-}
-
-pub fn check_only_one_self_code_hash_in(source: Source) -> bool {
-    let script = load_script().unwrap_or_default();
-    let self_code_hash = script.code_hash();
-    let self_code_hashes = QueryIter::new(load_cell_type, source)
-        .filter(|type_| {
-            if let Some(type_) = type_ {
-                return type_.code_hash().as_slice() == self_code_hash.as_slice();
-            }
-            false
-        })
-        .collect::<Vec<_>>();
-    self_code_hashes.len() > 1
 }

--- a/lib/utils/src/lib.rs
+++ b/lib/utils/src/lib.rs
@@ -2,6 +2,7 @@
 
 extern crate alloc;
 
+use alloc::vec::Vec;
 use ckb_std::ckb_constants::Source;
 use ckb_std::ckb_types::packed::Script;
 use ckb_std::ckb_types::prelude::*;
@@ -9,7 +10,7 @@ use ckb_std::ckb_types::util::hash::Blake2bBuilder;
 use ckb_std::debug;
 use ckb_std::high_level::{
     load_cell, load_cell_data, load_cell_lock_hash, load_cell_type, load_cell_type_hash,
-    load_input, QueryIter,
+    load_input, load_script, QueryIter,
 };
 
 pub use mime::MIME;
@@ -125,4 +126,18 @@ pub fn calc_capacity_sum(lock_hash: &[u8; 32], source: Source) -> u128 {
         .filter(|cell| cell.lock().calc_script_hash().raw_data().as_ref() == lock_hash)
         .map(|cell| cell.capacity().unpack() as u128)
         .sum()
+}
+
+pub fn check_only_one_self_code_hash_in(source: Source) -> bool {
+    let script = load_script().unwrap_or_default();
+    let self_code_hash = script.code_hash();
+    let self_code_hashes = QueryIter::new(load_cell_type, source)
+        .filter(|type_| {
+            if let Some(type_) = type_ {
+                return type_.code_hash().as_slice() == self_code_hash.as_slice();
+            }
+            false
+        })
+        .collect::<Vec<_>>();
+    self_code_hashes.len() > 1
 }

--- a/lib/utils/src/mime.rs
+++ b/lib/utils/src/mime.rs
@@ -141,9 +141,7 @@ impl MIME {
 }
 
 fn check_range_validate(array: &[u8], range: &Range<usize>) -> Result<(), Error> {
-    let Some(end) = range.clone().last() else {
-        return Err(Error::ContentOutOfRange);
-    };
+    let end: usize = range.end;
     debug!("len = {}, end = {end}", array.len());
     if array.len() <= end {
         return Err(Error::ContentOutOfRange);

--- a/lib/utils/src/mime.rs
+++ b/lib/utils/src/mime.rs
@@ -1,3 +1,5 @@
+use core::ops::Range;
+
 use alloc::ffi::CString;
 use alloc::str;
 use alloc::vec::Vec;
@@ -75,6 +77,9 @@ impl MIME {
                             .map_err(|_| Error::MutantIDNotValid)?
                             .try_into()
                             .unwrap();
+                        if mutants.contains(&mutant_id) {
+                            return Err(Error::DuplicateMutantId);
+                        }
                         mutants.push(mutant_id);
                     }
                 }
@@ -108,34 +113,53 @@ impl MIME {
         &mut self.params
     }
 
-    pub fn get_param(&self, content_type: &[u8], param: &str) -> Option<RangePair> {
+    pub fn get_param(&self, content_type: &[u8], param: &str) -> Result<Option<RangePair>, Error> {
         for (param_range, value_range) in self.params.iter() {
+            check_range_validate(content_type, param_range)?;
             if content_type[param_range.clone()] == param.as_bytes()[..] {
-                return Some(value_range.clone());
+                return Ok(Some(value_range.clone()));
             }
         }
-        None
+        Ok(None)
     }
 
-    pub fn verify_param(&self, content_type: &[u8], param: &str, value: &[u8]) -> bool {
+    pub fn verify_param(
+        &self,
+        content_type: &[u8],
+        param: &str,
+        value: &[u8],
+    ) -> Result<bool, Error> {
         for (param_range, value_range) in self.params.iter() {
+            check_range_validate(content_type, param_range)?;
             if content_type[param_range.clone()] == param.as_bytes()[..] {
-                return content_type[value_range.clone()] == value[..];
+                check_range_validate(content_type, value_range)?;
+                return Ok(content_type[value_range.clone()] == value[..]);
             }
         }
-        false
+        Ok(false)
     }
 }
 
-pub fn is_restricted_name(s: &str) -> bool {
+fn check_range_validate(array: &[u8], range: &Range<usize>) -> Result<(), Error> {
+    let Some(end) = range.clone().last() else {
+        return Err(Error::ContentOutOfRange);
+    };
+    debug!("len = {}, end = {end}", array.len());
+    if array.len() <= end {
+        return Err(Error::ContentOutOfRange);
+    }
+    Ok(())
+}
+
+fn is_restricted_name(s: &str) -> bool {
     s.starts_with(|c: char| c.is_ascii_alphanumeric() || c == '*') && is_restricted_str(s)
 }
 
-pub fn is_restricted_name_patched(s: &str) -> bool {
+fn is_restricted_name_patched(s: &str) -> bool {
     s == "mutant[]" || is_restricted_name(s)
 }
 
-pub fn is_restricted_value_char(c: char) -> bool {
+fn is_restricted_value_char(c: char) -> bool {
     c.is_ascii_alphanumeric()
         || matches!(
             c,
@@ -143,11 +167,11 @@ pub fn is_restricted_value_char(c: char) -> bool {
         )
 }
 
-pub fn is_restricted_str(s: &str) -> bool {
+fn is_restricted_str(s: &str) -> bool {
     s.chars().all(is_restricted_char)
 }
 
-pub fn is_restricted_char(c: char) -> bool {
+fn is_restricted_char(c: char) -> bool {
     c.is_ascii_alphanumeric()
         || matches!(
             c,
@@ -155,7 +179,7 @@ pub fn is_restricted_char(c: char) -> bool {
         )
 }
 
-pub const fn is_ows(c: char) -> bool {
+const fn is_ows(c: char) -> bool {
     c == ' ' || c == '\t'
 }
 
@@ -210,7 +234,7 @@ fn parse_param(
     }
 }
 
-pub fn parse_quoted_value(s: &str) -> Result<usize, Error> {
+fn parse_quoted_value(s: &str) -> Result<usize, Error> {
     let mut len = 0;
     let mut escaped = false;
     for c in s.chars() {
@@ -236,21 +260,25 @@ fn test_basic() {
     assert!(MIME::str_parse("image/png;immortal=true").is_ok());
     assert!(MIME::str_parse("image/png;immortal=true;mutant[]=2,3,4,5").is_ok());
     assert!(MIME::str_parse("image/png;immortal=true;mutant[]=2,3,4,5")
-        .map_err(|_| "mutant verify_param")
+        .map_err(|_| "mutant str_parse")
         .unwrap()
         .verify_param(
             b"image/png;immortal=true;mutant[]=2,3,4,5",
             "mutant[]",
             b"2,3,4,5"
-        ));
-    assert!(MIME::str_parse("image/png;immortal=true;mutant[]=2,3,4,5")
+        )
         .map_err(|_| "mutant verify_param")
+        .unwrap());
+    assert!(MIME::str_parse("image/png;immortal=true;mutant[]=2,3,4,5")
+        .map_err(|_| "mutant str_parse")
         .unwrap()
         .verify_param(
             b"image/png;immortal=true;mutant[]=2,3,4,5",
             "immortal",
             b"true"
-        ));
+        )
+        .map_err(|_| "mutant verify_param")
+        .unwrap());
     assert!(MIME::str_parse("image/").is_err());
     assert!(MIME::str_parse("image/;").is_err());
     assert!(MIME::str_parse("/;").is_err());

--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -358,7 +358,8 @@ fn test_cluster_agent() {
     let input_cell = build_normal_input(&mut context, capacity);
     let proxy_type_id = build_script_args(&input_cell, 0);
     let mut proxy_type_arg = proxy_type_id.to_vec();
-    proxy_type_arg.push(1);
+    let power = 1;
+    proxy_type_arg.push(power);
     println!("Proxy_type_arg len: {}", proxy_type_arg.len());
     let proxy_type = build_spore_type_script(
         &mut context,
@@ -378,7 +379,11 @@ fn test_cluster_agent() {
     let input_cell = build_normal_input(&mut context, agent_capacity);
 
     let agent_type = build_spore_type_script(&mut context, &agent_out_point, cluster_type_id);
-    let agent_out_cell = build_output_cell_with_type_id(&mut context, capacity, agent_type.clone());
+    let agent_out_cell = build_output_cell_with_type_id(
+        &mut context,
+        capacity + 10u64.pow(power as u32),
+        agent_type.clone(),
+    );
 
     let tx = TransactionBuilder::default()
         .inputs(vec![input_cell])


### PR DESCRIPTION
# Description
`payment` function needs to pin a flag in `script.args` filed, which can impact the calculation of script hash, however, if this payment flag changed in `transfer` operation, we cannot just use `GroupInput` and `GroupOutput` to identify the related scripts both in `Input` and `Output` field, so this change of payment should be described as `Burn/Mint` in one transaction.

when we use payment flag to check the user's payment is wether enough, since different scripts in Mutant or Proxy cell act independently, and these scripts use the same logic to run a payment check process, so, for example, if a same owner of two Mutant cells with different `mutant_id` disappeared in `CellDep` field at the same time, one payment in transaction will be duplicated in use to meet this two Mutant scripts' requirement.

# Tasks list
- [x] close #15 
- [x] close #36
- [x] close #40 
- [x] close #39 