### PR TITLE
chore: record code_hash of contracts in CI

### DIFF
--- a/.github/workflows/capsule.yaml
+++ b/.github/workflows/capsule.yaml
@@ -24,11 +24,7 @@ jobs:
             target-dir: "build/release"
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+      - uses: actions/checkout@v4
       
       - name: Prepare capsule v0.10.2
         run: |

--- a/.github/workflows/capsule.yaml
+++ b/.github/workflows/capsule.yaml
@@ -1,5 +1,6 @@
 name: Capsule build/test
 on:
+  push:
   pull_request:
     paths:
       - contracts/**
@@ -7,14 +8,27 @@ on:
       - tests/**
 
 jobs:
-  capsule:
+  capsule-build-and-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: debug
+            cargo-option: ""
+            target-dir: "build/debug"
+          - target: testnet
+            cargo-option: "--release"
+            target-dir: "build/release"
+          - target: mainnet
+            cargo-option: "--release -- --features release_export"
+            target-dir: "build/release"
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-            toolchain: stable
-            override: true
+          toolchain: stable
+          override: true
       
       - name: Prepare capsule v0.10.2
         run: |
@@ -28,10 +42,48 @@ jobs:
         run: cargo install cross --git https://github.com/cross-rs/cross
 
       - name: Capsule build
-        run: capsule build
+        run: capsule build ${{ matrix.cargo-option }}
 
-      - name: Capsule test -- --nocapture
-        run: capsule test
+      - name: Capsule test
+        run: capsule test ${{ matrix.cargo-option }}
 
-      
-        
+      - name: List all the contract binaries of ${{ github.ref }}
+        run: ls -l ${{ matrix.target-dir }}
+
+      - name: Archive the contract binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: contract-binaries-${{ matrix.target }}
+          path: ${{ matrix.target-dir }}
+  
+  record-code-hash:
+    needs: capsule-build-and-test
+    strategy:
+      matrix:
+        target: [debug, testnet, mainnet]
+    runs-on: ubuntu-20.04
+    steps:
+      # TODO: add this codehash util into the `tests` directory
+      - name: Checkout a code_hash tool
+        uses: actions/checkout@v4
+        with:
+          repository: Flouse/spore-contract
+          ref: codehash-tool
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: contract-binaries-${{ matrix.target }}
+
+      - run: |
+          pwd
+          ls build
+          ls
+          ls /home/runner/work/spore-contract/spore-contract
+
+      - name: Build codehash-tool
+        working-directory: build
+        run: cargo build
+
+      - name: Record code_hash of contract binaries
+        working-directory: build
+        run: ./target/debug/code_hash

--- a/.github/workflows/capsule.yaml
+++ b/.github/workflows/capsule.yaml
@@ -50,7 +50,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: contract-binaries-${{ matrix.target }}-${{ github.sha }}
-          path: ${{ matrix.target-dir }}
+          path: |
+            build/debug
+            build/release
     outputs:
       spore-contract-ref: ${{ github.sha }}
   
@@ -72,6 +74,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: contract-binaries-${{ matrix.target }}-${{ needs.capsule-build-and-test.outputs.spore-contract-ref }}
+          path: build
 
       - name: Build codehash-tool
         working-directory: build

--- a/.github/workflows/capsule.yaml
+++ b/.github/workflows/capsule.yaml
@@ -46,11 +46,13 @@ jobs:
       - name: List all the contract binaries of ${{ github.ref }}
         run: ls -l ${{ matrix.target-dir }}
 
-      - name: Archive the contract binaries
+      - name: Archive the contract binaries ${{ github.sha }}
         uses: actions/upload-artifact@v4
         with:
-          name: contract-binaries-${{ matrix.target }}
+          name: contract-binaries-${{ matrix.target }}-${{ github.sha }}
           path: ${{ matrix.target-dir }}
+    outputs:
+      spore-contract-ref: ${{ github.sha }}
   
   record-code-hash:
     needs: capsule-build-and-test
@@ -60,6 +62,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       # TODO: add this codehash util into the `tests` directory
+      # or, simply use `ckb-cli util blake2b --binary-path ...` to get the codehash
       - name: Checkout a code_hash tool
         uses: actions/checkout@v4
         with:
@@ -68,13 +71,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: contract-binaries-${{ matrix.target }}
-
-      - run: |
-          pwd
-          ls build
-          ls
-          ls /home/runner/work/spore-contract/spore-contract
+          name: contract-binaries-${{ matrix.target }}-${{ needs.capsule-build-and-test.outputs.spore-contract-ref }}
 
       - name: Build codehash-tool
         working-directory: build
@@ -82,4 +79,6 @@ jobs:
 
       - name: Record code_hash of contract binaries
         working-directory: build
-        run: ./target/debug/code_hash
+        run: |
+          echo "spore-contract-commit: ${{ needs.capsule-build-and-test.outputs.spore-contract-ref }}\n"
+          ./target/debug/code_hash


### PR DESCRIPTION
## Changes
- refactor the .github/workflows/capsule.yaml
- run capsule build and test for 3 targets: debug, testnet and mainnet release
- archive the contract binaries to github artifacts
- Record code_hash of contract binaries

## Preview
![image](https://github.com/sporeprotocol/spore-contract/assets/1297478/2d6fddbc-e710-4d66-9091-ae804a9dace4)
