### PR TITLE
feat: change payment from u8 to u64

### DIFF
--- a/.github/workflows/devnet.yaml
+++ b/.github/workflows/devnet.yaml
@@ -61,10 +61,8 @@ jobs:
         run: bash prepare.sh -b $GITHUB_HEAD_REF
 
       - name: Start devenv services
-        run: npm run test:start > /dev/null 2>&1 &
-
-      - name: Wait for 5 seconds
-        run: sleep 5
+        working-directory: spore-devenv
+        run: npm run test:start
 
       - name: Move generated config file to spore-sdk
         working-directory: spore-devenv

--- a/.github/workflows/devnet.yaml
+++ b/.github/workflows/devnet.yaml
@@ -61,8 +61,10 @@ jobs:
         run: bash prepare.sh -b $GITHUB_HEAD_REF
 
       - name: Start devenv services
-        working-directory: spore-devenv
-        run: npm run test:start
+        run: npm run test:start > /dev/null 2>&1 &
+
+      - name: Wait for 5 seconds
+        run: sleep 5
 
       - name: Move generated config file to spore-sdk
         working-directory: spore-devenv

--- a/contracts/spore/src/entry.rs
+++ b/contracts/spore/src/entry.rs
@@ -241,7 +241,7 @@ fn process_transfer() -> Result<(), Error> {
 }
 
 fn verify_extension(mime: &MIME, op: Operation, argv: Vec<u8>) -> Result<(), Error> {
-    let mut payment_map: BTreeMap<[u8; 32], u8> = BTreeMap::new();
+    let mut payment_map: BTreeMap<[u8; 32], u64> = BTreeMap::new();
     let mut extension_hash = [0u8; 32];
     for mutant_id in mime.mutants.iter() {
         let mutant_index =
@@ -328,12 +328,6 @@ fn check_payment(
             *payment_threshold += threshold;
             *payment_threshold
         };
-<<<<<<< HEAD
-        let minimal_payment = 10u128.pow(payment_power as u32);
-
-        debug!("check mutant payment: {minimal_payment}");
-=======
->>>>>>> ab12bb7 (feat: change payment from u8 to u64)
         if input_capacity + minimal_payment > output_capacity {
             return Err(Error::ExtensionPaymentNotEnough);
         }

--- a/contracts/spore/src/entry.rs
+++ b/contracts/spore/src/entry.rs
@@ -21,7 +21,7 @@ use spore_types::generated::spore::SporeData;
 use spore_utils::{
     calc_capacity_sum, check_spore_address, compatible_load_cluster_data, extract_spore_action,
     find_position_by_lock_hash, find_position_by_type, find_position_by_type_args, load_self_id,
-    verify_type_id, MIME,
+    verify_type_id, MIME, MUTANT_ID_LEN, MUTANT_ID_WITH_PAYMENT_LEN,
 };
 
 use crate::hash::{CLUSTER_AGENT_CODE_HASHES, CLUSTER_CODE_HASHES};
@@ -306,28 +306,34 @@ fn verify_extension(mime: &MIME, op: Operation, argv: Vec<u8>) -> Result<(), Err
 
 fn check_payment(
     mutant_index: usize,
-    payment_map: &mut BTreeMap<[u8; 32], u8>,
+    payment_map: &mut BTreeMap<[u8; 32], u64>,
 ) -> Result<(), Error> {
     let mutant_type = load_cell_type(mutant_index, CellDep)?.unwrap_or_default();
     let args = mutant_type.args().raw_data();
-    // CAUTION: only check 33 size pattern, leave room for user customization
-    if args.len() > 32 {
+    // CAUTION: only check bytes in [32, 40) pattern, leave room for user customization
+    if args.len() > MUTANT_ID_LEN {
+        if args.len() < MUTANT_ID_WITH_PAYMENT_LEN {
+            return Err(Error::InvalidExtensionPaymentFormat);
+        }
         // we need a payment
         let self_lock_hash = load_cell_lock_hash(0, GroupOutput)?;
         let mutant_lock_hash = load_cell_lock_hash(mutant_index, CellDep)?;
 
         let input_capacity = calc_capacity_sum(&self_lock_hash, Input);
         let output_capacity = calc_capacity_sum(&mutant_lock_hash, Output);
-        let payment_power = {
-            let previous_power = payment_map.entry(mutant_lock_hash).or_default();
-            let current_power = args.get(32).cloned().unwrap_or(0);
-            let power = *previous_power + current_power;
-            *previous_power = power;
-            power
+        let minimal_payment = {
+            let range = MUTANT_ID_LEN..MUTANT_ID_WITH_PAYMENT_LEN;
+            let threshold = u64::from_le_bytes(args[range].try_into().unwrap_or_default());
+            let payment_threshold = payment_map.entry(mutant_lock_hash).or_default();
+            *payment_threshold += threshold;
+            *payment_threshold
         };
+<<<<<<< HEAD
         let minimal_payment = 10u128.pow(payment_power as u32);
 
         debug!("check mutant payment: {minimal_payment}");
+=======
+>>>>>>> ab12bb7 (feat: change payment from u8 to u64)
         if input_capacity + minimal_payment > output_capacity {
             return Err(Error::ExtensionPaymentNotEnough);
         }

--- a/lib/errors/src/error.rs
+++ b/lib/errors/src/error.rs
@@ -36,6 +36,7 @@ pub enum Error {
     InvalidProxyOperation = 30,
     ImmutableProxyFieldModification,
     InvalidProxyID,
+    InvalidProxyArgs,
 
     // cluster_agent errors
     InvalidAgentOperation = 40,
@@ -69,6 +70,7 @@ pub enum Error {
     ExtensionCellNotInDep,
     ExtensionPaymentNotEnough,
     ClusterRequiresMutantApplied,
+    InvalidExtensionPaymentFormat,
 
     // mime errors
     Illformed = 80,

--- a/lib/utils/src/lib.rs
+++ b/lib/utils/src/lib.rs
@@ -25,6 +25,12 @@ pub mod co_build_types {
 
 mod mime;
 
+pub const MUTANT_ID_LEN: usize = 32;
+pub const MUTANT_ID_WITH_PAYMENT_LEN: usize = MUTANT_ID_LEN + 8;
+
+pub const CLUSTER_PROXY_ID_LEN: usize = 32;
+pub const CLUSTER_PROXY_ID_WITH_PAYMENT_LEN: usize = CLUSTER_PROXY_ID_LEN + 8;
+
 pub fn load_self_id() -> Result<Vec<u8>, Error> {
     Ok(load_script()?.args().raw_data()[..32].to_vec())
 }
@@ -147,10 +153,10 @@ pub fn find_position_by_lock_hash(lock_hash: &[u8; 32], source: Source) -> Optio
     QueryIter::new(load_cell_lock_hash, source).position(|hash| hash[..] == lock_hash[..])
 }
 
-pub fn calc_capacity_sum(lock_hash: &[u8; 32], source: Source) -> u128 {
+pub fn calc_capacity_sum(lock_hash: &[u8; 32], source: Source) -> u64 {
     QueryIter::new(load_cell, source)
         .filter(|cell| cell.lock().calc_script_hash().raw_data().as_ref() == lock_hash)
-        .map(|cell| cell.capacity().unpack() as u128)
+        .map(|cell| cell.capacity().unpack())
         .sum()
 }
 

--- a/tests/src/tests/cluster.rs
+++ b/tests/src/tests/cluster.rs
@@ -200,7 +200,7 @@ fn test_cluster_agent_mint() {
         build_spore_type_script(&mut context, &agent_out_point, cluster_id.to_vec().into());
     let agent_out_cell = build_normal_output_cell_with_type(&mut context, agent_type.clone())
         .as_builder()
-        .capacity((UNIFORM_CAPACITY + 10).pack())
+        .capacity((2 * CAPACITY_UNIT).pack())
         .build();
 
     let tx = TransactionBuilder::default()

--- a/tests/src/utils/mod.rs
+++ b/tests/src/utils/mod.rs
@@ -19,6 +19,7 @@ pub mod co_build;
 mod internal;
 
 pub const UNIFORM_CAPACITY: u64 = 1000u64;
+pub const CAPACITY_UNIT: u64 = 100_000_000;
 
 pub fn build_serialized_cluster_data(name: &str, description: &str) -> ClusterData {
     ClusterData::new_builder()
@@ -64,9 +65,10 @@ pub fn build_spore_type_script_with_payment(
     context: &mut Context,
     out_point: &OutPoint,
     args: &[u8; 32],
-    payment: u8,
+    payment: u64,
 ) -> Option<Script> {
-    let args = vec![args.to_vec(), vec![payment]].concat();
+    let payment_in_ckb = payment * CAPACITY_UNIT;
+    let args = vec![args.to_vec(), payment_in_ckb.to_le_bytes().to_vec()].concat();
     context.build_script_with_hash_type(out_point, ScriptHashType::Data1, args.into())
 }
 


### PR DESCRIPTION
# Description
we've discussed it's non-sense that using the same payment check method with Omni and ACP, because it's a bit inconvenient to users.

so the result is to change payment flag from `u8` to `u64`, which directly represents the CKB capacity, not the power of 10.

BTW, `spore-sdk` should adapt to this change later.

cc @Flouse @ShookLyngs 

# Related Issues
- [x] https://github.com/sporeprotocol/spore-contract/issues/43